### PR TITLE
Harden CI/CD: PR-title version markers, manual deploys, pinned toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/automated_deployment.yml
+++ b/.github/workflows/automated_deployment.yml
@@ -4,119 +4,164 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: >-
+          Version bump. "none" redeploys current main showing the latest
+          existing version tag; patch/minor/major cut a new tag + release.
+        type: choice
+        required: true
+        default: none
+        options: [none, patch, minor, major]
 
 env:
   BASE_URL: /${{ github.event.repository.name }}
 
 permissions:
-  contents: write
-  pages: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  auto-tag:
-    name: 🏷️ Generate Version Tag
+  version:
+    name: Resolve version
     runs-on: ubuntu-latest
     outputs:
-      new_tag: ${{ steps.tagger.outputs.NEW_TAG }}
+      new_tag: ${{ steps.resolve.outputs.NEW_TAG }}
+      display_version: ${{ steps.resolve.outputs.DISPLAY_VERSION }}
+      deploy: ${{ steps.resolve.outputs.DEPLOY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Configure Git
-        run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
-
-      - name: Determine and Create Tag
-        id: tagger
+      - name: Resolve bump, candidate tag and display version
+        id: resolve
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          BUMP_INPUT: ${{ inputs.bump }}
+          REF: ${{ github.ref }}
         run: |
-          COMMIT_MSG=$(git log --format=%B -n 1 HEAD)
-          if ! echo "$COMMIT_MSG" | grep -qE '#major|#minor|#patch'; then
-            echo "NEW_TAG=" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+          set -euo pipefail
 
-          VERSION=$(git describe --abbrev=0 --tags --match="v[0-9]*" 2>/dev/null || echo "v0.0.0")
-          VNUM1=$(echo "$VERSION" | cut -d. -f1 | sed 's/v//')
-          VNUM2=$(echo "$VERSION" | cut -d. -f2)
-          VNUM3=$(echo "$VERSION" | cut -d. -f3)
-
-          if echo "$COMMIT_MSG" | grep -q '#major'; then
-            VNUM1=$((VNUM1 + 1)); VNUM2=0; VNUM3=0
-          elif echo "$COMMIT_MSG" | grep -q '#minor'; then
-            VNUM2=$((VNUM2 + 1)); VNUM3=0
+          BUMP=none
+          DEPLOY=false
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$REF" != "refs/heads/main" ]; then
+              echo "::error::Manual deploys are only allowed from main (got $REF)."
+              exit 1
+            fi
+            BUMP="${BUMP_INPUT:-none}"
+            DEPLOY=true
           else
-            VNUM3=$((VNUM3 + 1))
+            SUBJECT=$(git log -1 --format=%s HEAD)
+            if echo "$SUBJECT" | grep -q '#major'; then BUMP=major; DEPLOY=true
+            elif echo "$SUBJECT" | grep -q '#minor'; then BUMP=minor; DEPLOY=true
+            elif echo "$SUBJECT" | grep -q '#patch'; then BUMP=patch; DEPLOY=true
+            fi
           fi
 
-          NEW_TAG="v$VNUM1.$VNUM2.$VNUM3"
-          GIT_COMMIT=$(git rev-parse HEAD)
+          BASE=$(git describe --abbrev=0 --tags --match="v[0-9]*" 2>/dev/null || echo "")
+          NEW_TAG=""
+          DISPLAY=""
 
-          if git tag --contains "$GIT_COMMIT" | grep -q "^v" ||
-             git ls-remote --tags origin | grep -q "refs/tags/$NEW_TAG$"; then
-            echo "NEW_TAG=" >> $GITHUB_OUTPUT
-            exit 0
+          if [ "$BUMP" != "none" ]; then
+            VERSION="${BASE:-v0.0.0}"
+            VNUM1=$(echo "$VERSION" | cut -d. -f1 | sed 's/v//')
+            VNUM2=$(echo "$VERSION" | cut -d. -f2)
+            VNUM3=$(echo "$VERSION" | cut -d. -f3)
+            case "$BUMP" in
+              major) VNUM1=$((VNUM1 + 1)); VNUM2=0; VNUM3=0 ;;
+              minor) VNUM2=$((VNUM2 + 1)); VNUM3=0 ;;
+              patch) VNUM3=$((VNUM3 + 1)) ;;
+            esac
+            NEW_TAG="v$VNUM1.$VNUM2.$VNUM3"
+
+            EXISTING_ON_HEAD=$(git tag --points-at HEAD --list 'v[0-9]*' | head -n1)
+            if [ -n "$EXISTING_ON_HEAD" ]; then
+              echo "HEAD is already tagged as $EXISTING_ON_HEAD; not cutting a new tag."
+              NEW_TAG=""
+              DISPLAY="$EXISTING_ON_HEAD"
+            elif git ls-remote --tags origin | grep -q "refs/tags/$NEW_TAG$"; then
+              echo "::error::Candidate tag $NEW_TAG already exists on origin; refusing to continue."
+              exit 1
+            else
+              DISPLAY="$NEW_TAG"
+            fi
+          else
+            DISPLAY="$BASE"
           fi
 
-          echo "NEW_TAG=$NEW_TAG" >> $GITHUB_OUTPUT
+          if [ "$DEPLOY" = "true" ] && [ -z "$DISPLAY" ]; then
+            echo "::error::No existing v* tag found and no bump requested; cannot resolve a version to display."
+            exit 1
+          fi
 
-          git remote set-url origin "https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY"
-          git tag "$NEW_TAG"
-          git push origin "$NEW_TAG"
-
-  release:
-    name: 📦 Create GitHub Release
-    needs: auto-tag
-    if: needs.auto-tag.outputs.new_tag != ''
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ needs.auto-tag.outputs.new_tag }}
-          name: ${{ needs.auto-tag.outputs.new_tag }}
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          {
+            echo "NEW_TAG=$NEW_TAG"
+            echo "DISPLAY_VERSION=$DISPLAY"
+            echo "DEPLOY=$DEPLOY"
+          } >> "$GITHUB_OUTPUT"
 
   deploy:
-    name: 🌐 Deploy JupyterBook
-    needs: [auto-tag, release]
-    if: needs.auto-tag.outputs.new_tag != ''
+    name: Build and deploy
+    needs: version
+    if: needs.version.outputs.deploy == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: Introduction to Bioinformatics
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup GitHub Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: 18.x
+          node-version: 22
+          cache: npm
 
-      - name: Install MyST Markdown
-        run: npm install -g mystmd
+      - name: Install dependencies
+        run: npm ci
 
-      - name: Prepend Version Tag to Markdown
+      - name: Prepend version banner to book chapters
         env:
-          VERSION_TAG: ${{ needs.auto-tag.outputs.new_tag }}
+          VERSION_TAG: ${{ needs.version.outputs.display_version }}
         run: |
+          set -euo pipefail
+
+          command -v yq >/dev/null || { echo "::error::yq is not available on this runner."; exit 1; }
+          if ! echo "$VERSION_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::VERSION_TAG '$VERSION_TAG' is not a vX.Y.Z version."
+            exit 1
+          fi
+
+          mapfile -t FILES < <(yq -r '.project.toc[].file' myst.yml)
+          if [ "${#FILES[@]}" -eq 0 ]; then
+            echo "::error::No files found in myst.yml project.toc."
+            exit 1
+          fi
+
           echo "📦 Using tag: $VERSION_TAG"
 
-          for file in $(find . -name "*.md"); do
+          for file in "${FILES[@]}"; do
+            if [ -z "$file" ] || [ "$file" = "null" ]; then
+              echo "::error::myst.yml toc contains an entry without a file: key."
+              exit 1
+            fi
+            [ -f "$file" ] || { echo "::error::toc entry '$file' does not exist."; exit 1; }
+            [ "$(sed -n 1p "$file")" = "---" ] || { echo "::error::'$file' does not start with YAML frontmatter."; exit 1; }
+            [ "$(grep -c '^---$' "$file")" -ge 2 ] || { echo "::error::'$file' has no closing frontmatter delimiter."; exit 1; }
+
             awk -v version="$VERSION_TAG" '
               BEGIN {
                 in_frontmatter = 0
@@ -140,38 +185,37 @@ jobs:
               }
               { print }
             ' "$file" > tmp && mv tmp "$file"
+
+            grep -qF "This content is part of version: $VERSION_TAG" "$file" || {
+              echo "::error::Banner was not injected into '$file'."
+              exit 1
+            }
           done
 
       - name: Build HTML
-        run: myst build --html
+        run: npx myst build --html
 
-      - name: Upload Artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./_build/html
 
       - name: Deploy to Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
-  cleanup:
-    name: 🧹 Clean Up Old Releases
-    needs: deploy
-    if: needs.auto-tag.outputs.new_tag != ''
+  release:
+    name: Tag and release
+    needs: [version, deploy]
+    if: needs.version.outputs.new_tag != ''
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install GitHub CLI
-        run: sudo apt-get install gh -y
-
-      - name: Auth with GitHub CLI
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
-
-      - name: Delete Releases and Tags (Keep Latest 5)
-        run: |
-          gh release list --limit 100 | sort -r -k3 | tail -n +6 | while read -r tag _ _; do
-            echo "Deleting release: $tag"
-            gh release delete "$tag" --yes
-            git push origin --delete "$tag"
-          done
+      - name: Create tag and release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: ${{ needs.version.outputs.new_tag }}
+          name: ${{ needs.version.outputs.new_tag }}
+          target_commitish: ${{ github.sha }}
+          generate_release_notes: true

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -1,25 +1,56 @@
-name: Check jupyterbook build
+name: Build check
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   build:
-    name: Build book with jupyterbook
+    name: Build book with MyST
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Publishing status notice
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          {
+            echo "## Publishing status"
+            if echo "$PR_TITLE" | grep -q '#major'; then
+              echo "This PR title contains \`#major\`: squash-merging it **will publish** a new major version of the reader."
+            elif echo "$PR_TITLE" | grep -q '#minor'; then
+              echo "This PR title contains \`#minor\`: squash-merging it **will publish** a new minor version of the reader."
+            elif echo "$PR_TITLE" | grep -q '#patch'; then
+              echo "This PR title contains \`#patch\`: squash-merging it **will publish** a new patch version of the reader."
+            else
+              echo "No version marker in the PR title: squash-merging will merge the changes but **will not publish** them to the live reader."
+              echo ""
+              echo "To publish on merge, add \`#patch\`, \`#minor\` or \`#major\` to the PR title. To publish later, use *Actions → Deploy online book → Run workflow*."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
         with:
-          node-version: 18.x
+          node-version: 22
+          cache: npm
 
-      - name: Install MyST Markdown
-        run: npm install -g mystmd
+      - name: Install dependencies
+        run: npm ci
 
       - name: Build HTML
-        run: myst build --html
+        run: npx myst build --html
 
-      - name: Upload Artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload site preview artifact
+        uses: actions/upload-artifact@v7
         with:
-          path: ./_build/html
+          name: site-preview-pr-${{ github.event.pull_request.number }}
+          path: _build/html
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ _answers/*
 .DS_Store
 *.ipynb_checkpoints
 .vscode
+
+node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,15 +321,82 @@ As we have seen in Section X.X, there are key similarities and differences betwe
 %#%[Not sure what the Section X.X refers to.]
 ```
 
-### Editing and publishing chapters
+---
 
-Since this reader is under iterative development, it is beneficial for all contributors to know how they can update and publish their individual chapters. The repository uses a GitHub workflow, using GitHub actions,
-that fully automates the deployment, release and publishing of the reader. Contributors can initiate this workflow through their commit message to the repository.
+### Publishing and deployment
 
-When an edit has been made to a chapter, the contributor has to consider the magnitude of their commit. A small update with small fixes or changes should be considered a patch update. A larger revision of a chapter, which could include new sections, removed sections or new imagery should be considered a minor update. A complete overhaul of one or more chapters that affects the reader as a whole should be considered a major update. When a decision according to the above logic has been made, the commit message should end in one of the corresponding categories:
-- #patch (this will increment the version of the reader by 0.0.1 and initiate the deployment, release and publishing workflow).
-- #minor (this will increment the version of the reader by 0.1.0 and initiate the deployment, release and publishing workflow).
-- #major (this will increment the version of the reader by 1.0.0 and intiatie the deployment, release and publishing workflow).
-- Omitting the #category at the end of the commit will add the changes to the repository, but will not initiate the deployment, release and publishing workflow. This is useful if you are planning to stack a bunch of commits, for which you don't want the reader to be re-deployed every single commit. Just make sure that the last commit has a #category at the end of the commit message, so that your changes are published and visible in the reader.
+Changes reach the published reader through pull requests:
 
-You can check on the progress of the workflow by going to the "Actions" tab in the GitHub repository. The "Deployment" action's "Build HTML" job will print potential error or warning messages that a contributor needs to fix in order for the reader to work properly. 
+1. Create a branch and open a pull request against `main`.
+2. Every pull request automatically runs the **Build check** workflow, which builds
+   the book with the exact MyST version pinned in `package.json`. The workflow's
+   summary contains a **Publishing status** notice telling you whether merging will
+   publish, and a downloadable `site-preview` artifact (kept for 7 days) with the
+   rendered HTML.
+3. Merge using **squash merge**. The pull request title becomes the commit message
+   on `main`, which is what controls publishing.
+
+#### Version markers in the pull request title
+
+To publish the reader when your pull request is merged, add one of the following
+markers anywhere in the **pull request title** (not the commit messages):
+
+- `#patch` — small fixes or changes; increments the version by 0.0.1.
+- `#minor` — larger revision of a chapter (new/removed sections, new imagery);
+  increments the version by 0.1.0.
+- `#major` — an overhaul affecting the reader as a whole; increments the version
+  by 1.0.0.
+
+Merging **without** a marker adds your changes to `main` but does not publish them.
+This is useful for stacking several pull requests; the next merge with a marker
+(or a manual deploy) publishes everything merged so far. If a title contains more
+than one marker, the largest one wins.
+
+A successful publish deploys the site, creates a git tag `vX.Y.Z`, and creates a
+GitHub release with automatically generated notes. Each chapter page shows a
+banner with the published version.
+
+#### Manual deploys
+
+If you forgot a marker, or want to publish accumulated changes without a new pull
+request, use the manual deploy: GitHub → **Actions** → **Deploy online book** →
+**Run workflow**, and choose a `bump`:
+
+- `none` — redeploys the current content of `main` without creating a new
+  version; the banner shows the latest existing version tag.
+- `patch` / `minor` / `major` — creates a new version tag and release, then
+  deploys.
+
+#### Verifying a deploy
+
+- The **Actions** tab shows the run; the *Build and deploy* job's **Build HTML**
+  step prints any MyST errors or warnings to fix.
+- The live reader is at <https://introduction.bioinformatics.nl> (served from
+  <https://wur-bioinformatics.github.io/introduction-to-bioinformatics/>).
+- Check the version banner at the top of any chapter and the release list on
+  GitHub.
+
+#### Building locally
+
+You need Node.js 22 (LTS) and npm. Then:
+
+```none
+npm ci            # install the pinned MyST version
+npm run start     # live preview at http://localhost:3000 while editing
+npm run build     # full HTML build into _build/html (same command CI runs)
+```
+
+`make html` and `make start` wrap the same commands.
+
+#### Troubleshooting
+
+- **Build check fails on a PR**: open the failed run's *Build HTML* step; fix the
+  reported MyST errors and push again.
+- **Deploy fails after merging**: no tag or release is created unless the deploy
+  succeeds, so simply fix the cause and re-run the workflow (Actions →
+  *Re-run failed jobs*), or trigger a manual deploy.
+- **Merged with a marker but nothing happened**: markers only work in the pull
+  request *title* (squash merge). Run a manual deploy with the intended bump.
+- **Several marked PRs merged in quick succession**: deploys queue one at a time
+  and only the newest queued run executes; all content is still published, but
+  only that run's marker decides the version bump.

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,25 @@
-INPUTS:=*md myst.yml images/**/* plugins/* style/* references.bib BIF_logo.png
+INPUTS:=*.md myst.yml images/**/* plugins/* style/* references.bib BIF_logo.png
 
-.PHONY: all
+.PHONY: all html pdf start clean
 
 all: html
 
-pdf: _build/pdf
-
 html: _build/html
 
-_build/pdf: $(INPUTS)
-	jupyter-book build --pdf
-#	jupyter-book build --builder pdfhtml --all .
-#	mv _build/html _build/pdf_html
+pdf: exports
 
-_build/html: $(INPUTS)
-	jupyter-book build --builder html --all .
-#	sed -i.bak 's/@media/\/*@media/g' _build/html/_static/custom.css
+_build/html: $(INPUTS) node_modules
+	npx myst build --html
 
-#_build/dir_html: $(INPUTS)
-#	jupyter-book build --builder dirhtml --all .
+# Requires typst and/or a LaTeX toolchain installed locally
+exports: $(INPUTS) node_modules
+	npx myst build --pdf
+
+node_modules: package-lock.json
+	npm ci
+
+start: node_modules
+	npx myst start
 
 clean:
 	rm -rf _build exports

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "introduction-to-bioinformatics",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "introduction-to-bioinformatics",
+      "devDependencies": {
+        "mystmd": "1.10.1"
+      }
+    },
+    "node_modules/mystmd": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/mystmd/-/mystmd-1.10.1.tgz",
+      "integrity": "sha512-nczabm7R8PmoqJVqKpaijTr1kxdwnY+hRoFC7b+NEUdxW5yZZ8n/CuJlMJKlHtG/pA4o3Ia2RP/0Ra3UPj6sFg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "myst": "dist/myst.cjs"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "introduction-to-bioinformatics",
+  "private": true,
+  "scripts": {
+    "start": "myst start",
+    "build": "myst build --html",
+    "build:pdf": "myst build --pdf"
+  },
+  "devDependencies": {
+    "mystmd": "1.10.1"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-jupyter-book==2.0.0b2


### PR DESCRIPTION
- Read #patch/#minor/#major from the squash commit subject (= PR title); the old full-message grep never matched squash merges, leaving the live site stale at v1.0.0 since Aug 2025
- Add workflow_dispatch manual deploy with a bump choice (none/patch/minor/major); "none" redeploys without cutting a version
- Reorder jobs to version (compute only) -> deploy -> release, so a failed build leaves no tag or release and reruns are safe
- Create tag+release atomically via the release action after deploy succeeds
- Remove the cleanup job that pruned releases and force-deleted tags
- Pin mystmd 1.10.1 via package.json/package-lock.json; npm ci + npm cache in both workflows (verified the book builds cleanly with 1.10.1)
- Node 22, current action majors, per-job least-privilege permissions
- Limit version-banner injection to myst.yml toc files with loud guards; rendered banner output verified byte-identical to the old script
- PR build check: publishing-status notice in the step summary, per-PR concurrency cancel, downloadable 7-day site preview artifact
- Add dependabot for github-actions and npm
- Update Makefile to the MyST CLI; drop unused requirements.txt
- Rewrite the CONTRIBUTING.md publishing section to document all of this